### PR TITLE
Try fix 404 on resume

### DIFF
--- a/content/Scratch/en/about.md
+++ b/content/Scratch/en/about.md
@@ -48,7 +48,7 @@ bash,
 [camL](http://caml.inria.fr),
 [Scheme](http://mitpress.mit.edu/sicp/full-text/book/book.html)...
 
-[My full resume](/Scratch/files/resume)
+[My full resume](/Scratch/files/cv.pdf)
 
 ## Old stuff
 


### PR DESCRIPTION
I got a 404 on your Resume link. I think this will fix it for the English version.

Otherwise, thanks for all your resources! I especially liked _Learn Haskell Fast and Hard_ and the description of your Hakyll configuration.